### PR TITLE
refactor(main): export Air as default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ import {switchLatest, switchMap} from './operators/Switch'
 
 const air = <T> (o: Observable<T>) => new Air(o)
 
-export class Air<T> implements Observable<T> {
+export default class Air<T> implements Observable<T> {
   constructor (private src: Observable<T>) {}
 
   subscribe (observer: Observer<T>, scheduler: Scheduler = createScheduler()): Subscription {


### PR DESCRIPTION
easier to consume when the library exposes on one variable

BREAKING CHANGE: `Air` is exported an default module