### PR TITLE
refactor(marble): reduce marble size from 10ms to 1ms

### DIFF
--- a/src/internal/TestOptions.ts
+++ b/src/internal/TestOptions.ts
@@ -5,6 +5,6 @@
 export const DEFAULT_OPTIONS = {
   subscriptionStart: 200,
   subscriptionStop: 2000,
-  marbleSize: 10,
+  marbleSize: 1,
   rafTimeout: 16
 }

--- a/test/test.Combine.ts
+++ b/test/test.Combine.ts
@@ -19,14 +19,14 @@ describe('combine()', () => {
       ])
     })
     assert.deepEqual(results, [
-      EVENT.next(230, 'bqx'),
-      EVENT.next(240, 'cqx'),
-      EVENT.next(250, 'crx'),
-      EVENT.next(250, 'cry'),
-      EVENT.next(260, 'dry'),
-      EVENT.next(270, 'dsy'),
-      EVENT.next(270, 'dsz'),
-      EVENT.complete(300)
+      EVENT.next(203, 'bqx'),
+      EVENT.next(204, 'cqx'),
+      EVENT.next(205, 'crx'),
+      EVENT.next(205, 'cry'),
+      EVENT.next(206, 'dry'),
+      EVENT.next(207, 'dsy'),
+      EVENT.next(207, 'dsz'),
+      EVENT.complete(210)
     ])
   })
 })

--- a/test/test.Debounce.ts
+++ b/test/test.Debounce.ts
@@ -10,7 +10,7 @@ describe('debounce()', () => {
   it('should not fire until the source pauses for atleast the give unit of time', () => {
     const sh = createTestScheduler()
     const {results} = sh.start(() =>
-      debounce(10, sh.Hot(fromMarble('012-345-678|')))
+      debounce(1, sh.Hot(fromMarble('012-345-678|')))
     )
     t.strictEqual(toMarble(results), '---2---5---|')
   })

--- a/test/test.Delay.ts
+++ b/test/test.Delay.ts
@@ -11,13 +11,13 @@ import {createTestScheduler} from '../src/schedulers/TestScheduler'
 describe('delay()', () => {
   it('should delay the source events', () => {
     const sh = createTestScheduler()
-    const {results} = sh.start(() => delay(20, sh.Hot(fromMarble('12345|'))))
+    const {results} = sh.start(() => delay(2, sh.Hot(fromMarble('12345|'))))
     t.strictEqual(toMarble(results), '--12345|')
   })
 
   it('should forward error', () => {
     const sh = createTestScheduler()
-    const {results} = sh.start(() => delay(20, sh.Hot(fromMarble('--#|'))))
+    const {results} = sh.start(() => delay(2, sh.Hot(fromMarble('--#|'))))
     t.strictEqual(toMarble(results), '--#--|')
   })
 

--- a/test/test.Frames.ts
+++ b/test/test.Frames.ts
@@ -10,13 +10,13 @@ import {frames} from '../src/sources/Frames'
 
 describe('frames()', () => {
   it('should emit requestAnimationFrame events', () => {
-    const sh = createTestScheduler(10)
-    const {results} = sh.start(() => scan(i => i + 1, -1, frames()), 200, 250)
+    const sh = createTestScheduler(1)
+    const {results} = sh.start(() => scan(i => i + 1, -1, frames()), 200, 205)
     t.strictEqual(toMarble(results), '-0123')
   })
 
   it('should capture internal errors', () => {
-    const sh = createTestScheduler(20)
+    const sh = createTestScheduler(2)
     const reduce = (i: number) => {
       if (i === 5) throwError('Yo Air')
       return i + 1

--- a/test/test.Interval.ts
+++ b/test/test.Interval.ts
@@ -15,9 +15,9 @@ describe('interval()', () => {
   it('should emit values every t ms', () => {
     const sh = createTestScheduler()
     const {results} = sh.start(
-      () => scan(i => i + 1, -1, interval(10)),
+      () => scan(i => i + 1, -1, interval(1)),
       200,
-      250
+      205
     )
     t.strictEqual(toMarble(results), '-0123')
   })
@@ -36,7 +36,7 @@ describe('interval()', () => {
   it('should stop after error', () => {
     const sh = createTestScheduler()
     const {results} = sh.start(() =>
-      scan(i => (i === 5 ? throwError('Yay!') : i + 1), 0, interval(20))
+      scan(i => (i === 5 ? throwError('Yay!') : i + 1), 0, interval(2))
     )
     const expected = '--1-2-3-4-5-#'
     t.strictEqual(toMarble(results), expected)

--- a/test/test.Marble.ts
+++ b/test/test.Marble.ts
@@ -41,18 +41,18 @@ describe('marble()', () => {
     const message = '   -(ABC)-(PQR)-|'
     const actual = fromMarble(message)
     const expected = [
-      EVENT.next(210, 'ABC'),
-      EVENT.next(230, 'PQR'),
-      EVENT.complete(250)
+      EVENT.next(201, 'ABC'),
+      EVENT.next(203, 'PQR'),
+      EVENT.complete(205)
     ]
     assert.deepEqual(actual, expected)
   })
 
   it('should create multi-letter messages', () => {
     const actual = toMarble([
-      EVENT.next(210, 'ABC'),
-      EVENT.next(230, 'PQR'),
-      EVENT.complete(250)
+      EVENT.next(201, 'ABC'),
+      EVENT.next(203, 'PQR'),
+      EVENT.complete(205)
     ])
     const expected = '-(ABC)-(PQR)-|'
     assert.deepEqual(actual, expected)
@@ -69,10 +69,10 @@ describe('marble()', () => {
     const message = '--1-2-3-4'
     const actual = fromMarble(message)
     const expected = [
-      EVENT.next(220, 1),
-      EVENT.next(240, 2),
-      EVENT.next(260, 3),
-      EVENT.next(280, 4)
+      EVENT.next(202, 1),
+      EVENT.next(204, 2),
+      EVENT.next(206, 3),
+      EVENT.next(208, 4)
     ]
 
     assert.deepEqual(actual, expected)

--- a/test/test.MergeMap.ts
+++ b/test/test.MergeMap.ts
@@ -24,9 +24,9 @@ describe('mergeMap()', () => {
         const c$ = sh.Hot(c)
         const source$$ = sh.Hot(
           next(200, a$),
-          next(215, b$),
-          next(220, c$),
-          complete(300)
+          next(201, b$),
+          next(202, c$),
+          complete(203)
         )
         return mergeMap(conc$, (i: any) => i, source$$)
       })
@@ -50,9 +50,9 @@ describe('mergeMap()', () => {
         const c$ = sh.Hot(c)
         const source$$ = sh.Hot(
           next(200, a$),
-          next(215, b$),
-          next(220, c$),
-          complete(300)
+          next(201, b$),
+          next(202, c$),
+          complete(203)
         )
         return mergeMap(conc$, (i: any) => i, source$$)
       })
@@ -76,9 +76,9 @@ describe('mergeMap()', () => {
         const c$ = sh.Hot(c)
         const source$$ = sh.Hot(
           next(200, a$),
-          next(215, b$),
-          next(220, c$),
-          complete(300)
+          next(201, b$),
+          next(202, c$),
+          complete(203)
         )
         return mergeMap(concurr$, (i: any) => i, source$$)
       })
@@ -103,9 +103,9 @@ describe('mergeMap()', () => {
         const c$ = sh.Hot(c)
         const source$$ = sh.Hot(
           next(200, a$),
-          next(215, b$),
-          next(220, c$),
-          complete(300)
+          next(201, b$),
+          next(202, c$),
+          complete(203)
         )
         return mergeMap(concurr$, (i: any) => i, source$$)
       })

--- a/test/test.Sample.ts
+++ b/test/test.Sample.ts
@@ -15,68 +15,68 @@ describe('sample()', () => {
   it('should sample multiple sources', () => {
     const sh = createTestScheduler()
     const a$ = sh.Hot([
-      EVENT.next(210, 'A0'),
-      EVENT.next(230, 'A1'),
-      EVENT.next(250, 'A2'),
-      EVENT.complete(250)
+      EVENT.next(201, 'A0'),
+      EVENT.next(203, 'A1'),
+      EVENT.next(205, 'A2'),
+      EVENT.complete(205)
     ])
     const b$ = sh.Hot([
-      EVENT.next(210, 'B0'),
-      EVENT.next(220, 'B1'),
-      EVENT.next(230, 'B2'),
-      EVENT.next(240, 'B3'),
-      EVENT.complete(240)
+      EVENT.next(201, 'B0'),
+      EVENT.next(202, 'B1'),
+      EVENT.next(203, 'B2'),
+      EVENT.next(204, 'B3'),
+      EVENT.complete(204)
     ])
     const S$ = sh.Hot([
-      EVENT.next(211, '#'),
-      EVENT.next(221, '#'),
-      EVENT.next(231, '#'),
-      EVENT.next(241, '#'),
-      EVENT.next(251, '#'),
-      EVENT.complete(251)
+      EVENT.next(201, '#'),
+      EVENT.next(202, '#'),
+      EVENT.next(203, '#'),
+      EVENT.next(204, '#'),
+      EVENT.next(205, '#'),
+      EVENT.complete(205)
     ])
     const {results} = sh.start(() => sample(toArray, S$, [a$, b$]))
     t.deepEqual(results, [
-      EVENT.next(211, 'A0,B0'),
-      EVENT.next(221, 'A0,B1'),
-      EVENT.next(231, 'A1,B2'),
-      EVENT.next(241, 'A1,B3'),
-      EVENT.next(251, 'A2,B3'),
-      EVENT.complete(251)
+      EVENT.next(201, 'A0,B0'),
+      EVENT.next(202, 'A0,B1'),
+      EVENT.next(203, 'A1,B2'),
+      EVENT.next(204, 'A1,B3'),
+      EVENT.next(205, 'A2,B3'),
+      EVENT.complete(205)
     ])
   })
 
   it('should sample()', () => {
     const sh = createTestScheduler()
     const a$ = sh.Hot([
-      EVENT.next(210, 0),
-      EVENT.next(230, 1),
-      EVENT.next(250, 2),
-      EVENT.complete(250)
+      EVENT.next(201, 0),
+      EVENT.next(203, 1),
+      EVENT.next(205, 2),
+      EVENT.complete(205)
     ])
     const b$ = sh.Hot([
-      EVENT.next(210, 0),
-      EVENT.next(220, 1000),
-      EVENT.next(230, 2000),
-      EVENT.next(240, 3000),
-      EVENT.complete(240)
+      EVENT.next(201, 0),
+      EVENT.next(202, 1000),
+      EVENT.next(203, 2000),
+      EVENT.next(204, 3000),
+      EVENT.complete(204)
     ])
     const S$ = sh.Hot([
-      EVENT.next(211, '#'),
-      EVENT.next(221, '#'),
-      EVENT.next(231, '#'),
-      EVENT.next(241, '#'),
-      EVENT.next(251, '#'),
-      EVENT.complete(251)
+      EVENT.next(201, '#'),
+      EVENT.next(202, '#'),
+      EVENT.next(203, '#'),
+      EVENT.next(204, '#'),
+      EVENT.next(205, '#'),
+      EVENT.complete(205)
     ])
     const {results} = sh.start(() => sample((a, b) => a + b, S$, [a$, b$]))
     t.deepEqual(results, [
-      EVENT.next(211, 0 + 0),
-      EVENT.next(221, 0 + 1000),
-      EVENT.next(231, 1 + 2000),
-      EVENT.next(241, 1 + 3000),
-      EVENT.next(251, 2 + 3000),
-      EVENT.complete(251)
+      EVENT.next(201, 0 + 0),
+      EVENT.next(202, 0 + 1000),
+      EVENT.next(203, 1 + 2000),
+      EVENT.next(204, 1 + 3000),
+      EVENT.next(205, 2 + 3000),
+      EVENT.complete(205)
     ])
   })
 
@@ -86,10 +86,10 @@ describe('sample()', () => {
     const t2$ = sh.Hot(fromMarble('--a-b-c-d'))
     const {results} = sh.start(() => sample((a, b) => a + b, t2$, [t1$, t2$]))
     t.deepEqual(results, [
-      EVENT.next(220, 'Aa'),
-      EVENT.next(240, 'Bb'),
-      EVENT.next(260, 'Cc'),
-      EVENT.next(280, 'Dd')
+      EVENT.next(202, 'Aa'),
+      EVENT.next(204, 'Bb'),
+      EVENT.next(206, 'Cc'),
+      EVENT.next(208, 'Dd')
     ])
   })
 })


### PR DESCRIPTION
1ms provides us with a lot more flexibility interms of scheduling events.

BREAKING CHANGE: MarbleSize has been reduced to 1ms

fixes usage of scheduler.asap() with marbles